### PR TITLE
CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
 language: go
+
+before_script:
+  - ./check_gofmt.sh
+
 script: go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: go
 
+install:
+  - go get -u github.com/golang/lint/golint
+  # This is default if `install` not overridden:
+  - go get -t -v ./...
+
 before_script:
   - ./check_gofmt.sh
   - go vet ./...
+  - golint -set_exit_status ./...
 
 script: go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: go
 
 before_script:
   - ./check_gofmt.sh
+  - go vet ./...
 
 script: go test -v -race ./...

--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ $ git checkout -b my-new-feature
 $ go test -v ./...    # Run tests to make sure you have a good development environment and all works.
 ```
 
+Before pull requests you may also want to make sure that `go vet`, `gofmt` and `golint` passes:
+```sh
+$ go get -u github.com/golang/lint/golint
+$ golint ./...
+$ ./check_gofmt.sh
+$ go vet ./...
+```
+(otherwise that's done through our CI on pull request submission)
+
 Example Usage
 =============
 ```sh

--- a/check_gofmt.sh
+++ b/check_gofmt.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+EXITCODE=0
+
+for F in *.go
+do
+  gofmt -d "$F" | read -r
+  if [ $? -eq 0 ]
+  then
+    echo "Found incorrectly formatted go code:"
+    gofmt -d "$F"
+    EXITCODE=1
+  fi
+done
+
+if [ $EXITCODE -eq 0 ]
+then
+  echo 'All source code files were properly formatted using "gofmt".'
+else
+  echo 'Not all source code files are formatted using "gofmt".'
+fi
+
+exit $EXITCODE

--- a/cmd/kafka_consumer_group_exporter.go
+++ b/cmd/kafka_consumer_group_exporter.go
@@ -63,8 +63,8 @@ func main() {
 			Delegate: &kafkaClient,
 		}
 		collector := kafkaprom.NewPartitionInfoCollector(
-			&fanInClient,
 			context.Background(),
+			&fanInClient,
 			c.Duration("kafka-command-timeout"),
 			c.Int("max-concurrent-group-queries"),
 		)

--- a/mocks/collector.go
+++ b/mocks/collector.go
@@ -31,6 +31,9 @@ func (col *ConsumerGroupsCommandClient) DescribeGroup(_ context.Context, group s
 	return col.DescribeGroupFn(group)
 }
 
+// NewBasicConsumerGroupsCommandClient creates a new
+// ConsumerGroupsCommandClient with prepopulated functions. For mocking, you
+// can override the function implementations.
 func NewBasicConsumerGroupsCommandClient() *ConsumerGroupsCommandClient {
 	return &ConsumerGroupsCommandClient{
 		GroupsFn: func() ([]string, error) {

--- a/prometheus/collector.go
+++ b/prometheus/collector.go
@@ -102,7 +102,7 @@ func (p *PartitionInfoCollector) Collect(c chan<- prometheus.Metric) {
 			partitions, err := p.client.DescribeGroup(ctx, groupname)
 			cancel()
 			if err != nil {
-				log.Error("Could not describe group '%s': %s", groupname, err)
+				log.Errorf("Could not describe group '%s': %s", groupname, err)
 				p.groupDescribeErrors.WithLabelValues(groupname).Inc()
 				continue
 			}

--- a/prometheus/collector.go
+++ b/prometheus/collector.go
@@ -43,7 +43,7 @@ type PartitionInfoCollector struct {
 // NewPartitionInfoCollector returns a prometheus.Collector that queries Kafka
 // using client. concurrency sets an upper limit on the number concurrent Kafka
 // concumer group queries running.
-func NewPartitionInfoCollector(client exporter.ConsumerGroupInfoClient, ctx context.Context, execTimeout time.Duration, maxConcurrentQueries int) *PartitionInfoCollector {
+func NewPartitionInfoCollector(ctx context.Context, client exporter.ConsumerGroupInfoClient, execTimeout time.Duration, maxConcurrentQueries int) *PartitionInfoCollector {
 	if maxConcurrentQueries <= 0 {
 		log.Fatal("maxConcurrentQueries must be positive.")
 	}

--- a/prometheus/collector_test.go
+++ b/prometheus/collector_test.go
@@ -18,7 +18,7 @@ func TestPartitionInfoCollector(t *testing.T) {
 
 	timeout := 1 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	collector := NewPartitionInfoCollector(mocks.NewBasicConsumerGroupsCommandClient(), ctx, timeout, 4)
+	collector := NewPartitionInfoCollector(ctx, mocks.NewBasicConsumerGroupsCommandClient(), timeout, 4)
 	cancel()
 	registry.MustRegister(collector)
 


### PR DESCRIPTION
* `gofmt` check.
 * `go vet` check.
 * `golint` check.

Keeps the project healthy.

I've kept the fix commits separate from introducing the checks to make sure that they run/fail properly (didn't do that for `gofmt`, though, but it has worked on my other project).

I've had these checks in place for another projekt and it's useful to
automatically check syntax on pull requests from external committers as well as
making sure the code base is healthy.

Discussion point(s):

 - Should we version any of the tools to make sure they don't start breaking on new checks? Probably not too important, I think.