### PR TITLE
Added Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: go
 script: go test -v -race ./...
-before_install:
-  - go get github.com/mitchellh/gox
-after_success:
-  - gox -output "dist/{{.OS}}_{{.Arch}}_{{.Dir}}"
 before_deploy:
   - PLATFORMS=(darwin/386 darwin/amd64 freebsd/386 freebsd/amd64 freebsd/arm linux/386 linux/amd64 linux/arm windows/386 windows/amd64)
  # build binary for all archs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,48 @@
 language: go
 script: go test -v -race ./...
+before_install:
+  - go get github.com/mitchellh/gox
+after_success:
+  - gox -output "dist/{{.OS}}_{{.Arch}}_{{.Dir}}"
+before_deploy:
+  - PLATFORMS=(darwin/386 darwin/amd64 freebsd/386 freebsd/amd64 freebsd/arm linux/386 linux/amd64 linux/arm windows/386 windows/amd64)
+ # build binary for all archs
+  - |
+    for PLATFORM in "${PLATFORMS[@]}"; do
+      echo "Building $PLATFORM"
+      GOOS=${PLATFORM%/*}
+      GOARCH=${PLATFORM#*/}
+      if [ "$GOOS" = "windows" ]; then
+        build_cmd="GOOS=$GOOS GOARCH=$GOARCH go build -o kafka_consumer_group_exporter -ldflags '-w -s'"
+      else
+        build_cmd="CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -o kafka_consumer_group_exporter -ldflags '-d -w -s'"
+      fi
+      if ! eval $build_cmd; then
+        echo "Failed building kafka_consumer_group_exporter for $PLATFORM" && return 1
+      fi
+      if [ "$GOOS" = "windows" ]; then
+        zip kafka_consumer_group_exporter-${GOOS}-${GOARCH}.zip kafka_consumer_group_exporter
+      else
+        tar cvzf kafka_consumer_group_exporter-${GOOS}-${GOARCH}.tgz kafka_consumer_group_exporter
+      fi
+    done
+  - ls
+deploy:
+  provider: releases
+  api_key: $GH_TOKEN
+  file:
+    - "kafka_consumer_group_exporter-darwin-386.tgz"
+    - "kafka_consumer_group_exporter-darwin-amd64.tgz"
+
+    - "kafka_consumer_group_exporter-freebsd-386.tgz"
+    - "kafka_consumer_group_exporter-freebsd-arm.tgz"
+    - "kafka_consumer_group_exporter-freebsd-amd64.tgz"
+
+    - "kafka_consumer_group_exporter-linux-386.tgz"
+    - "kafka_consumer_group_exporter-linux-arm.tgz"
+    - "kafka_consumer_group_exporter-linux-amd64.tgz"
+
+    - "kafka_consumer_group_exporter-windows-386.zip"
+    - "kafka_consumer_group_exporter-windows-amd64.zip"
+  on:
+    tags: yes


### PR DESCRIPTION
We need to tag the release and add a GitHub token as environment variable **GH_TOKEN**  with access to create deployments.

Travis Logs.
https://travis-ci.org/ashoksahoo/prometheus-kafka-consumer-group-exporter/builds/240132329

Release Page.
https://github.com/ashoksahoo/prometheus-kafka-consumer-group-exporter/releases/tag/travis-release-test
