### PR TITLE
log(scraping): log when unable to parse output

### DIFF
--- a/kafka/collector.go
+++ b/kafka/collector.go
@@ -88,13 +88,12 @@ func parseClientIDAndConsumerAddress(clientIDAndConsumerAddress string) (string,
 	return clientIDAndConsumerAddress[:splitPoint], clientIDAndConsumerAddress[splitPoint+len(Separator):]
 }
 
-func parseLong(what, value string) int64 {
+func parseLong(value string) (int64, error) {
 	longVal, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
-		log.Warn("unable to parse int for '%s'. String: %s", what, value)
-		return -1
+		return -1, err
 	}
-	return longVal
+	return longVal, nil
 }
 
 func parsePartitionInfo(line string) (*exporter.PartitionInfo, error) {
@@ -103,12 +102,26 @@ func parsePartitionInfo(line string) (*exporter.PartitionInfo, error) {
 		return nil, fmt.Errorf("malformed line: %s", line)
 	}
 
+	var err error
+
+	var currentOffset int64
+	currentOffset, err = parseLong(fields[3])
+	if err != nil {
+		log.Warn("unable to parse int for current offset. line: %s", line)
+	}
+
+	var lag int64
+	lag, err = parseLong(fields[5])
+	if err != nil {
+		log.Warn("unable to parse int for lag. line: %s", line)
+	}
+
 	clientID, consumerAddress := parseClientIDAndConsumerAddress(fields[6])
 	partitionInfo := &exporter.PartitionInfo{
 		Topic:           fields[1],
 		PartitionID:     fields[2],
-		CurrentOffset:   parseLong("CurrentOffset", fields[3]),
-		Lag:             parseLong("Lag", fields[5]),
+		CurrentOffset:   currentOffset,
+		Lag:             lag,
 		ClientID:        clientID,
 		ConsumerAddress: consumerAddress,
 	}

--- a/kafka/collector.go
+++ b/kafka/collector.go
@@ -88,9 +88,10 @@ func parseClientIDAndConsumerAddress(clientIDAndConsumerAddress string) (string,
 	return clientIDAndConsumerAddress[:splitPoint], clientIDAndConsumerAddress[splitPoint+len(Separator):]
 }
 
-func parseLong(value string) int64 {
+func parseLong(what, value string) int64 {
 	longVal, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
+		log.Warn("unable to parse int for '%s'. String: %s", what, value)
 		return -1
 	}
 	return longVal
@@ -106,8 +107,8 @@ func parsePartitionInfo(line string) (*exporter.PartitionInfo, error) {
 	partitionInfo := &exporter.PartitionInfo{
 		Topic:           fields[1],
 		PartitionID:     fields[2],
-		CurrentOffset:   parseLong(fields[3]),
-		Lag:             parseLong(fields[5]),
+		CurrentOffset:   parseLong("CurrentOffset", fields[3]),
+		Lag:             parseLong("Lag", fields[5]),
 		ClientID:        clientID,
 		ConsumerAddress: consumerAddress,
 	}


### PR DESCRIPTION
We were seeing a bunch of offsets with value `-1` for over 22 hours the other day. Most certainly this is because of our `-1` fallback when converting to int. We have no idea what the original string was, but this logging will hopefully help.