### PR TITLE
Fix inactive consumer case

### DIFF
--- a/kafka/parsing.go
+++ b/kafka/parsing.go
@@ -155,7 +155,7 @@ var (
 	// Parser for Kafka 0.10.2.1. Since we are unsure if the column widths are dynamic, we are using `\s+` for delimiters.
 	kafka0_10_2_1DescribeGroupParser = mustBuildNewRegexpParser(
 		regexp.MustCompile(`TOPIC\s+PARTITION\s+CURRENT-OFFSET\s+LOG-END-OFFSET\s+LAG\s+CONSUMER-ID\s+HOST\s+CLIENT-ID`),
-		regexp.MustCompile(`(?P<topic>[a-zA-Z0-9\\._\\-]+)\s+(?P<partitionId>\d+|-)\s+(?P<currentOffset>\d+|-)\s+(\d+|-)\s+(?P<lag>\d+|-)\s+(?P<consumerId>\S+)\s*/(?P<consumerAddress>\S+)\s+(?P<clientId>\S+)`),
+		regexp.MustCompile(`(?P<topic>[a-zA-Z0-9\\._\\-]+)\s+(?P<partitionId>\d+|-)\s+(?P<currentOffset>\d+|-)\s+(\d+|-)\s+(?P<lag>\d+|-)\s+(?P<consumerId>[^/\s]+)\s*/?(?P<consumerAddress>\S+)\s+(?P<clientId>\S+)`),
 	)
 
 	// Parser for Kafka 0.10.1.X.

--- a/kafka/parsing_test.go
+++ b/kafka/parsing_test.go
@@ -51,6 +51,33 @@ topic3            0          45              45              0          consumer
 	})
 }
 
+func TestParsingPartitionTableWithMissingValuesConsumerIdForKafkaVersion0_10_2_1(t *T) {
+	output := CommandOutput{
+        Stderr: "NOTE: When there is no active consumer CONSUMER_ID, HOST and CLIENT-ID is -\n",
+		Stdout: `
+TOPIC           PARTITION   CURRENT-OFFSET  LOG-END-OFFSET  LAG     CONSUMER-ID     HOST        CLIENT-ID
+TEST            0           109             134             25      -               -           -`,
+	}
+
+	expected := []exporter.PartitionInfo{
+		{
+			Topic:           "TEST",
+			PartitionID:     "0",
+			CurrentOffset:   109,
+			Lag:             25,
+			ClientID:        "-",
+			ConsumerAddress: "-",
+		},
+	}
+
+	t.Run("kafka0_10_2_1DescribeGroupParser", func(t *T) {
+		comparePartitionTable(t, kafka0_10_2_1DescribeGroupParser, output, expected)
+	})
+	t.Run("DefaultDescribeGroupParser", func(t *T) {
+		comparePartitionTable(t, DefaultDescribeGroupParser(), output, expected)
+	})
+}
+
 func TestParsingPartitionTableWithMissingValuesForKafkaVersion0_10_2_1(t *T) {
 	output := CommandOutput{
 		Stderr: "Note: This will only show information about consumers that use the Java consumer API (non-ZooKeeper-based consumers).\n",


### PR DESCRIPTION
In this case CONSUMER_ID, HOST and CLIENT_ID becomes -.

The current regex will fails as there is not / to detect.
Rework the consumerId group to not accept / so the zero or one operator
can work as expected